### PR TITLE
✨ feat(api): add GraphQL support to enhance data querying flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,81 @@ https://api.octagon-api.com/
 
 For more extensive documentation, go to the [API documentation](https://www.octagon-api.com/api-documentation)
 
+## 🔗 GraphQL API
+
+In addition to our REST endpoints, we now offer a GraphQL API for more flexible data querying.
+
+### GraphQL Endpoint
+
+```txt
+https://api.octagon-api.com/graphql
+```
+
+### Example Queries
+
+1. Get all rankings with champions and fighters:
+
+```graphql
+{
+  rankings {
+    id
+    categoryName
+    champion {
+      id
+      championName
+    }
+    fighters {
+      id
+      name
+    }
+  }
+}
+```
+
+2. Get information about a specific fighter:
+
+```graphql
+{
+  fighter(id: "jon-jones") {
+    name
+    category
+    wins
+    losses
+    draws
+  }
+}
+```
+
+3. Get all fighters:
+
+```graphql
+{
+  fighters {
+    id
+    name
+    category
+  }
+}
+```
+
+4. Get information about a specific division:
+
+```graphql
+{
+  division(id: "flyweight") {
+    categoryName
+    champion {
+      championName
+    }
+    fighters {
+      name
+    }
+  }
+}
+```
+
+For more detailed information on how to use our GraphQL API, please refer to our [API documentation](https://www.octagon-api.com/api-documentation).
+
 ## 🤖 Scripts
 
 |      Script       |     Params      | Function                                                                                           |
@@ -61,7 +136,7 @@ For more extensive documentation, go to the [API documentation](https://www.octa
 - **Front End**: Astro, Svelte
 - **PostCSS**: autoprefixer
 - **Scraper**: NodeJS and node-html-parser
-- **API**: hono
+- **API**: hono, GraphQL
 - **Image processing**: sharp
 
 ## 🦾 Providers

--- a/api/index.js
+++ b/api/index.js
@@ -1,24 +1,89 @@
-import { Hono } from 'hono'
-
 import fighters from '@db/fighters.json'
 import rankings from '@db/rankings.json'
+import { makeExecutableSchema } from '@graphql-tools/schema'
+import { graphqlServer } from '@hono/graphql-server'
+import { Hono } from 'hono'
 
 const app = new Hono()
 
-app.get('/', (context) => context.text('Welcome to Octagon API'))
-app.get('/fighters', (context) => context.json(fighters))
-app.get('/rankings', (context) => context.json(rankings))
-app.get('/fighter/:fighterId', (context) => {
-  const fighterId = context.req.param('fighterId')
+const typeDefs = `
+  type Query {
+    rankings: [Division!]!
+    division(id: ID!): Division
+    fighters: [Fighter!]!
+    fighter(id: ID!): Fighter
+  }
+
+  type Division {
+    id: ID!
+    categoryName: String!
+    champion: Champion
+    fighters: [DivisionFighter!]!
+  }
+
+  type Champion {
+    id: ID!
+    championName: String!
+  }
+
+  type DivisionFighter {
+    id: ID!
+    name: String!
+  }
+
+  type Fighter {
+    id: ID!
+    category: String!
+    draws: String!
+    imgUrl: String!
+    losses: String!
+    name: String!
+    nickname: String
+    wins: String!
+    status: String!
+    placeOfBirth: String
+    trainsAt: String
+    fightingStyle: String
+    age: String
+    height: String
+    weight: String
+    octagonDebut: String
+    reach: String
+    legReach: String
+  }
+`
+
+const resolvers = {
+  Query: {
+    rankings: () => rankings,
+    division: (_, { id }) => rankings.find((division) => division.id === id),
+    fighters: () => Object.entries(fighters).map(([id, fighter]) => ({ id, ...fighter })),
+    fighter: (_, { id }) => (fighters[id] ? { id, ...fighters[id] } : null),
+  },
+}
+
+const schema = makeExecutableSchema({ typeDefs, resolvers })
+
+app.use(
+  '/graphql',
+  graphqlServer({
+    schema,
+    graphiql: true,
+  })
+)
+
+app.get('/', (c) => c.text('Welcome to Octagon API'))
+app.get('/fighters', (c) => c.json(fighters))
+app.get('/rankings', (c) => c.json(rankings))
+app.get('/fighter/:fighterId', (c) => {
+  const fighterId = c.req.param('fighterId')
   const fighter = fighters[fighterId]
-
-  return fighter ? context.json(fighter) : context.json({ message: 'Fighter not found' }, 404)
+  return fighter ? c.json(fighter) : c.json({ message: 'Fighter not found' }, 404)
 })
-app.get('/division/:divisionId', (context) => {
-  const divisionId = context.req.param('divisionId')
+app.get('/division/:divisionId', (c) => {
+  const divisionId = c.req.param('divisionId')
   const division = rankings.find((division) => division.id === divisionId)
-
-  return division ? context.json(division) : context.json({ message: 'Division not found' }, 404)
+  return division ? c.json(division) : c.json({ message: 'Division not found' }, 404)
 })
 
 export default app

--- a/package.json
+++ b/package.json
@@ -27,8 +27,11 @@
     "@astrojs/mdx": "3.1.3",
     "@astrojs/sitemap": "3.1.6",
     "@astrojs/svelte": "5.7.0",
+    "@graphql-tools/schema": "^10.0.4",
+    "@hono/graphql-server": "^0.5.0",
     "astro": "4.12.2",
     "astro-expressive-code": "0.35.3",
+    "graphql": "^16.9.0",
     "svelte": "4.2.18"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,12 +17,21 @@ importers:
       '@astrojs/svelte':
         specifier: 5.7.0
         version: 5.7.0(astro@4.12.2(@types/node@20.14.12)(typescript@5.5.4))(svelte@4.2.18)(typescript@5.5.4)(vite@5.3.5(@types/node@20.14.12))
+      '@graphql-tools/schema':
+        specifier: ^10.0.4
+        version: 10.0.4(graphql@16.9.0)
+      '@hono/graphql-server':
+        specifier: ^0.5.0
+        version: 0.5.0(hono@4.5.1)
       astro:
         specifier: 4.12.2
         version: 4.12.2(@types/node@20.14.12)(typescript@5.5.4)
       astro-expressive-code:
         specifier: 0.35.3
         version: 0.35.3(astro@4.12.2(@types/node@20.14.12)(typescript@5.5.4))
+      graphql:
+        specifier: ^16.9.0
+        version: 16.9.0
       svelte:
         specifier: 4.2.18
         version: 4.2.18
@@ -656,6 +665,35 @@ packages:
 
   '@formatjs/intl-localematcher@0.5.4':
     resolution: {integrity: sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==}
+
+  '@graphql-tools/merge@9.0.4':
+    resolution: {integrity: sha512-MivbDLUQ+4Q8G/Hp/9V72hbn810IJDEZQ57F01sHnlrrijyadibfVhaQfW/pNH+9T/l8ySZpaR/DpL5i+ruZ+g==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/schema@10.0.4':
+    resolution: {integrity: sha512-HuIwqbKxPaJujox25Ra4qwz0uQzlpsaBOzO6CVfzB/MemZdd+Gib8AIvfhQArK0YIN40aDran/yi+E5Xf0mQww==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/utils@10.3.3':
+    resolution: {integrity: sha512-p0zCctE+kXsXb5FCJmA3DoucQmB5eSkrtyBAaEcjbnz8OVbriSJx2WNEyzttiHv2qanBe/AK/YiyHD/5Nsj76Q==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-typed-document-node/core@3.2.0':
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@hono/graphql-server@0.5.0':
+    resolution: {integrity: sha512-lF+AwPEDiisDFS/GAB/QelJXIwEEnVPBB0jpGAmeU/sp5PS/YMTMEZiorvmthMgkHFfaH8uKNVRGD2pxWM5HsQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      hono: '>=3.0.0'
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -1525,6 +1563,10 @@ packages:
       typescript:
         optional: true
 
+  cross-inspect@1.0.1:
+    resolution: {integrity: sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==}
+    engines: {node: '>=16.0.0'}
+
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
@@ -2134,6 +2176,10 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  graphql@16.9.0:
+    resolution: {integrity: sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
@@ -3827,6 +3873,10 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  value-or-promise@1.0.12:
+    resolution: {integrity: sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==}
+    engines: {node: '>=12'}
+
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
 
@@ -4557,6 +4607,37 @@ snapshots:
   '@formatjs/intl-localematcher@0.5.4':
     dependencies:
       tslib: 2.6.3
+
+  '@graphql-tools/merge@9.0.4(graphql@16.9.0)':
+    dependencies:
+      '@graphql-tools/utils': 10.3.3(graphql@16.9.0)
+      graphql: 16.9.0
+      tslib: 2.6.3
+
+  '@graphql-tools/schema@10.0.4(graphql@16.9.0)':
+    dependencies:
+      '@graphql-tools/merge': 9.0.4(graphql@16.9.0)
+      '@graphql-tools/utils': 10.3.3(graphql@16.9.0)
+      graphql: 16.9.0
+      tslib: 2.6.3
+      value-or-promise: 1.0.12
+
+  '@graphql-tools/utils@10.3.3(graphql@16.9.0)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
+      cross-inspect: 1.0.1
+      dset: 3.1.3
+      graphql: 16.9.0
+      tslib: 2.6.3
+
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.9.0)':
+    dependencies:
+      graphql: 16.9.0
+
+  '@hono/graphql-server@0.5.0(hono@4.5.1)':
+    dependencies:
+      graphql: 16.9.0
+      hono: 4.5.1
 
   '@humanwhocodes/module-importer@1.0.1': {}
 
@@ -5573,6 +5654,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.5.4
 
+  cross-inspect@1.0.1:
+    dependencies:
+      tslib: 2.6.3
+
   cross-spawn@7.0.3:
     dependencies:
       path-key: 3.1.1
@@ -6358,6 +6443,8 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  graphql@16.9.0: {}
 
   gray-matter@4.0.3:
     dependencies:
@@ -8619,6 +8706,8 @@ snapshots:
   urlpattern-polyfill@10.0.0: {}
 
   util-deprecate@1.0.2: {}
+
+  value-or-promise@1.0.12: {}
 
   vfile-location@5.0.3:
     dependencies:

--- a/src/pages/api-documentation.mdx
+++ b/src/pages/api-documentation.mdx
@@ -239,3 +239,117 @@ The JSON data is an **Object** that represents a division of fighters, containin
   ]
 }
 ```
+## GraphQL API
+
+In addition to our REST endpoints, we offer a GraphQL API for more flexible and efficient data querying. GraphQL allows you to request exactly the data you need in a single query, reducing over-fetching and under-fetching of data.
+
+### GraphQL Endpoint
+
+```
+POST https://api.octagon-api.com/graphql
+```
+
+### Schema Overview
+
+Our GraphQL schema includes the following main types:
+
+- `Query`: The entry point for all GraphQL queries
+- `Division`: Represents a weight division
+- `Fighter`: Represents a fighter
+- `Champion`: Represents a champion of a division
+
+### Example Queries
+
+1. Get all rankings with champions and fighters:
+
+```graphql
+query {
+  rankings {
+    id
+    categoryName
+    champion {
+      id
+      championName
+    }
+    fighters {
+      id
+      name
+    }
+  }
+}
+```
+
+2. Get detailed information about a specific fighter:
+
+```graphql
+query {
+  fighter(id: "jon-jones") {
+    name
+    nickname
+    category
+    wins
+    losses
+    draws
+    status
+    age
+    height
+    weight
+    reach
+    legReach
+  }
+}
+```
+
+3. Get information about a specific division:
+
+```graphql
+query {
+  division(id: "flyweight") {
+    categoryName
+    champion {
+      championName
+    }
+    fighters {
+      name
+      wins
+      losses
+    }
+  }
+}
+```
+
+### Using GraphQL in Your Application
+
+To use our GraphQL API:
+
+1. Send a POST request to `https://api.octagon-api.com/graphql`
+2. Set the `Content-Type` header to `application/json`
+3. In the request body, include a JSON object with a `query` key containing your GraphQL query
+
+Example using curl:
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ fighter(id: \"jon-jones\") { name category wins losses } }"}' \
+  https://api.octagon-api.com/graphql
+```
+
+### Benefits of Using GraphQL
+
+- **Flexible Queries**: Request multiple resources in a single query
+- **Precise Data Fetching**: Get only the data you need, nothing more, nothing less
+- **Strongly Typed**: The schema provides clear expectations about the structure of the data
+- **Introspection**: Explore the available data and schema using GraphQL introspection
+
+### GraphQL Playground
+
+For interactive exploration of our GraphQL API, you can use the GraphQL Playground available at:
+
+```
+https://api.octagon-api.com/graphql
+```
+
+This web-based tool allows you to write and execute queries, explore the schema, and view documentation.
+
+For more information on how to use GraphQL, please refer to the [official GraphQL documentation](https://graphql.org/learn/).


### PR DESCRIPTION
## Add GraphQL Support to Octagon API

### Description
This PR introduces GraphQL support to our Octagon API, enhancing the flexibility and efficiency of data querying for our users.

### Changes
- Implemented GraphQL schema for existing data models
- Added GraphQL resolvers for fighters, rankings, and divisions
- Integrated GraphQL server with existing Hono setup
- Updated API documentation to include GraphQL usage and examples
- Added GraphQL endpoint (`/graphql`) alongside existing REST endpoints

### Testing
- Manually tested GraphQL queries for all main data types
- Verified that existing REST endpoints continue to function as expected
- Tested GraphQL playground for interactive query exploration

### Documentation
- Updated `README.md` with GraphQL information
- Added detailed GraphQL documentation in `api-documentation.mdx`

### Dependencies
- Added `@graphql-tools/schema` for schema creation
- Added `@hono/graphql-server` for GraphQL server integration with Hono

### Notes for Reviewers
- Please check the GraphQL schema design for any potential improvements
- Verify that the integration doesn't impact the performance of existing endpoints
- Suggestions for additional example queries in the documentation are welcome